### PR TITLE
Add authorization middleware

### DIFF
--- a/cmd/vulnerability-db-api/main.go
+++ b/cmd/vulnerability-db-api/main.go
@@ -69,11 +69,6 @@ func main() {
 	e.GET("/findings/:id/events", a.ListFindingEventsByFinding)
 	e.GET("/findings/:id/mttr", a.GetFindingMTTR)
 
-	e.POST("/findings/awe", func(c echo.Context) (err error) {
-		c.Response().Write([]byte("AWE"))
-		return nil
-	})
-
 	e.GET("/events", a.ListFindingEvents)
 
 	e.GET("/stats/size", a.StatsSize)

--- a/cmd/vulnerability-db-api/main.go
+++ b/cmd/vulnerability-db-api/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/adevinta/vulnerability-db-api/pkg/api"
+	mddleware "github.com/adevinta/vulnerability-db-api/pkg/api/middleware"
 	"github.com/adevinta/vulnerability-db-api/pkg/storage/postgresql"
 
 	"github.com/labstack/echo"
@@ -27,10 +28,6 @@ func main() {
 
 	e := echo.New()
 
-	e.Use(middleware.Logger())
-	e.Use(middleware.Recover())
-	e.Pre(middleware.RemoveTrailingSlash())
-
 	e.Logger.SetLevel(parseLogLvl(config.Log.Level))
 
 	db, err := postgresql.NewDB(config.PSQL, e.Logger)
@@ -42,6 +39,11 @@ func main() {
 		MaxSize:     config.API.MaxSize,
 		DefaultSize: config.API.DefaultSize,
 	})
+
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+	e.Use(mddleware.Authorization(mddleware.NewTagAuthorizer(db, e.Logger)))
+	e.Pre(middleware.RemoveTrailingSlash())
 
 	e.GET("/sources", a.ListSources)
 	e.GET("/sources/:id", a.GetSource)
@@ -66,6 +68,11 @@ func main() {
 	e.GET("/findings/:id", a.GetFinding)
 	e.GET("/findings/:id/events", a.ListFindingEventsByFinding)
 	e.GET("/findings/:id/mttr", a.GetFindingMTTR)
+
+	e.POST("/findings/awe", func(c echo.Context) (err error) {
+		c.Response().Write([]byte("AWE"))
+		return nil
+	})
 
 	e.GET("/events", a.ListFindingEvents)
 

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -35,16 +35,23 @@ func Authorization(auth Authorizer) echo.MiddlewareFunc {
 	}
 }
 
+// Authorizer represents an authorization
+// mechanism applied to an HTTP request.
 type Authorizer interface {
 	Authorize(r *http.Request) error
 }
 
+// TagAuthorizer performs authorization based
+// on the TAG scheme for the authorization header.
 type TagAuthorizer struct {
 	db  storage.Storage
 	log echo.Logger
 }
 
-// NewTagAuthorizer builds a new Tag based Authorizer.
+// NewTagAuthorizer builds a new tag based authorizer.
+// This type of authorizer matches the tag passed in through
+// the authorization header against the tag associated with the
+// resource that the request tries to modify.
 func NewTagAuthorizer(db storage.Storage, log echo.Logger) *TagAuthorizer {
 	return &TagAuthorizer{
 		db,
@@ -52,7 +59,12 @@ func NewTagAuthorizer(db storage.Storage, log echo.Logger) *TagAuthorizer {
 	}
 }
 
-// TODO: Doc
+// Authorize authorizes HTTP request by verifying resource ownership.
+// It does so by retrieving the tag included in the http request's
+// authorization header and comparing it with the tags associated
+// with the resource that the request is trying to modify.
+// If request tag is among the ones associated with the resource,
+// then action is granted. Otherwise it is denied.
 func (a *TagAuthorizer) Authorize(r *http.Request) error {
 	if isReadMethod(r.Method) {
 		// Read HTTP methods do not

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -17,8 +17,9 @@ const (
 )
 
 var (
-	// ErrUnauthorized indicates request has been unauthorized by the middleware.
-	ErrUnauthorized = errors.New("Unauthorized")
+	errUnauthorized = errors.New("unauthorized")
+	errForbidden    = errors.New("forbidden")
+	errNotFound     = errors.New("resource not found")
 )
 
 // Authorization returns a new authorization middleware func
@@ -28,9 +29,7 @@ func Authorization(auth Authorizer) echo.MiddlewareFunc {
 		return func(c echo.Context) (err error) {
 			err = auth.Authorize(c.Request())
 			if err != nil {
-				if errors.Is(err, ErrUnauthorized) {
-					c.Response().WriteHeader(http.StatusUnauthorized)
-				}
+				c.Response().WriteHeader(errToStatus(err))
 				return
 			}
 			return next(c)
@@ -76,6 +75,9 @@ func (a *TagAuthorizer) Authorize(r *http.Request) error {
 	}
 
 	authTag := parseAuthTag(r.Header)
+	if authTag == "" {
+		return errUnauthorized
+	}
 
 	// Only makes sense to authorize update of
 	// Findings and Assets as these are the entities
@@ -90,38 +92,40 @@ func (a *TagAuthorizer) Authorize(r *http.Request) error {
 	}
 
 	// Deny by default
-	return ErrUnauthorized
+	return errUnauthorized
 }
 
 func (a *TagAuthorizer) authorizeFindingOp(findingID, tag string) error {
-	// TODO: Instead of retrieving finding and compare tag,
-	// perform directly a found/not found DB query?
-
 	f, err := a.db.GetFinding(findingID)
 	if err != nil {
-		a.log.Errorf("error authorizing finding op: %v", err)
+		a.log.Errorf("unexpected error authorizing finding op: %v", err)
 		return err
 	}
 
+	if f.ID == "" {
+		return errNotFound
+	}
+
 	if !contains(f.Target.Tags, tag) {
-		return ErrUnauthorized
+		return errForbidden
 	}
 
 	return nil
 }
 
 func (a *TagAuthorizer) authorizeTargetOp(targetID, tag string) error {
-	// TODO: Instead of retrieving target and compare tag,
-	// perform directly a found/not found DB query?
-
 	t, err := a.db.GetTarget(targetID)
 	if err != nil {
-		a.log.Errorf("error authorizing target op: %v", err)
+		a.log.Errorf("unexpected error authorizing target op: %v", err)
 		return err
 	}
 
+	if t.ID == "" {
+		return errNotFound
+	}
+
 	if !contains(t.Tags, tag) {
-		return ErrUnauthorized
+		return errForbidden
 	}
 
 	return nil
@@ -140,6 +144,9 @@ func parseAuthTag(headers http.Header) string {
 	if authH == "" {
 		return ""
 	}
+	if !strings.HasPrefix(authH, tagAuthSchemaPrefix) {
+		return ""
+	}
 	return strings.TrimPrefix(authH, tagAuthSchemaPrefix)
 }
 
@@ -148,6 +155,24 @@ func parseEntityID(path string) string {
 		return pathParts[2]
 	}
 	return ""
+}
+
+func errToStatus(err error) int {
+	var status int
+
+	if err == nil {
+		status = http.StatusOK
+	} else if errors.Is(err, errUnauthorized) {
+		status = http.StatusUnauthorized
+	} else if errors.Is(err, errForbidden) {
+		status = http.StatusForbidden
+	} else if errors.Is(err, errNotFound) {
+		status = http.StatusNotFound
+	} else {
+		status = http.StatusInternalServerError
+	}
+
+	return status
 }
 
 func isReadMethod(method string) bool {

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -68,8 +68,8 @@ func NewTagAuthorizer(db storage.Storage, log echo.Logger) *TagAuthorizer {
 // If request tag is among the ones associated with the resource,
 // then action is granted. Otherwise it is denied.
 func (a *TagAuthorizer) Authorize(r *http.Request) error {
-	if isReadMethod(r.Method) {
-		// Read HTTP methods do not
+	if !isModificationMethod(r.Method) {
+		// Only modification methods
 		// require authorization
 		return nil
 	}
@@ -79,7 +79,7 @@ func (a *TagAuthorizer) Authorize(r *http.Request) error {
 		return errUnauthorized
 	}
 
-	// Only makes sense to authorize update of
+	// Only makes sense to authorize modifications of
 	// Findings and Assets as these are the entities
 	// that are related with a team
 	if isFindingOp(r.URL.Path) {
@@ -175,10 +175,10 @@ func errToStatus(err error) int {
 	return status
 }
 
-func isReadMethod(method string) bool {
-	return method == http.MethodGet ||
-		method == http.MethodHead ||
-		method == http.MethodOptions
+func isModificationMethod(method string) bool {
+	return method == http.MethodPut ||
+		method == http.MethodPatch ||
+		method == http.MethodDelete
 }
 
 func contains(slice []string, s string) bool {

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -1,0 +1,151 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/adevinta/vulnerability-db-api/pkg/storage"
+	echo "github.com/labstack/echo"
+)
+
+const (
+	findingsOpPrefix = "/findings/"
+	targetsOpPrefix  = "/targets/"
+
+	tagAuthSchemaPrefix = "TAG tag="
+)
+
+var (
+	// ErrUnauthorized indicates request has been unauthorized by the middleware.
+	ErrUnauthorized = errors.New("Unauthorized")
+)
+
+// Authorization returns a new authorization middleware func
+// by using the input authorizer.
+func Authorization(auth Authorizer) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			err = auth.Authorize(c.Request())
+			if errors.Is(err, ErrUnauthorized) {
+				c.Response().WriteHeader(http.StatusUnauthorized)
+			}
+			return
+		}
+	}
+}
+
+type Authorizer interface {
+	Authorize(r *http.Request) error
+}
+
+type TagAuthorizer struct {
+	db  storage.Storage
+	log echo.Logger
+}
+
+// NewTagAuthorizer builds a new Tag based Authorizer.
+func NewTagAuthorizer(db storage.Storage, log echo.Logger) *TagAuthorizer {
+	return &TagAuthorizer{
+		db,
+		log,
+	}
+}
+
+// TODO: Doc
+func (a *TagAuthorizer) Authorize(r *http.Request) error {
+	if isReadMethod(r.Method) {
+		// Read HTTP methods do not
+		// require authorization
+		return nil
+	}
+
+	authTag := parseAuthTag(r.Header)
+
+	// Only makes sense to authorize update of
+	// Findings and Assets as these are the entities
+	// that are related with a team
+	if isFindingOp(r.URL.Path) {
+		findingID := parseEntityID(r.URL.Path)
+		return a.authorizeFindingOp(findingID, authTag)
+	}
+	if isTargetOp(r.URL.Path) {
+		targetID := parseEntityID(r.URL.Path)
+		return a.authorizeTargetOp(targetID, authTag)
+	}
+
+	// Deny by default
+	return ErrUnauthorized
+}
+
+func (a *TagAuthorizer) authorizeFindingOp(findingID, tag string) error {
+	// TODO: Instead of retrieving finding and compare tag,
+	// perform directly a found/not found DB query?
+
+	f, err := a.db.GetFinding(findingID)
+	if err != nil {
+		a.log.Errorf("error authorizing finding op: %w", err)
+		return err
+	}
+
+	if !contains(f.Target.Tags, tag) {
+		return ErrUnauthorized
+	}
+
+	return nil
+}
+
+func (a *TagAuthorizer) authorizeTargetOp(targetID, tag string) error {
+	// TODO: Instead of retrieving target and compare tag,
+	// perform directly a found/not found DB query?
+
+	t, err := a.db.GetTarget(targetID)
+	if err != nil {
+		a.log.Errorf("error authorizing target op: %w", err)
+		return err
+	}
+
+	if !contains(t.Tags, tag) {
+		return ErrUnauthorized
+	}
+
+	return nil
+}
+
+func isFindingOp(path string) bool {
+	return strings.HasPrefix(path, findingsOpPrefix)
+}
+
+func isTargetOp(path string) bool {
+	return strings.HasPrefix(path, targetsOpPrefix)
+}
+
+func parseAuthTag(headers http.Header) string {
+	authH := headers.Get("authorization")
+	if authH == "" {
+		return ""
+	}
+	return strings.TrimPrefix(authH, tagAuthSchemaPrefix)
+}
+
+func parseEntityID(path string) string {
+	if pathParts := strings.Split(path, "/"); len(pathParts) > 0 {
+		return pathParts[1]
+	}
+	return ""
+}
+
+func isReadMethod(method string) bool {
+	return method == http.MethodGet ||
+		method == http.MethodHead ||
+		method == http.MethodOptions
+}
+
+func contains(slice []string, s string) bool {
+	for _, ss := range slice {
+		if ss == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -96,7 +96,7 @@ func (a *TagAuthorizer) authorizeFindingOp(findingID, tag string) error {
 
 	f, err := a.db.GetFinding(findingID)
 	if err != nil {
-		a.log.Errorf("error authorizing finding op: %w", err)
+		a.log.Errorf("error authorizing finding op: %v", err)
 		return err
 	}
 
@@ -113,7 +113,7 @@ func (a *TagAuthorizer) authorizeTargetOp(targetID, tag string) error {
 
 	t, err := a.db.GetTarget(targetID)
 	if err != nil {
-		a.log.Errorf("error authorizing target op: %w", err)
+		a.log.Errorf("error authorizing target op: %v", err)
 		return err
 	}
 
@@ -141,8 +141,8 @@ func parseAuthTag(headers http.Header) string {
 }
 
 func parseEntityID(path string) string {
-	if pathParts := strings.Split(path, "/"); len(pathParts) > 0 {
-		return pathParts[1]
+	if pathParts := strings.Split(path, "/"); len(pathParts) > 1 {
+		return pathParts[2]
 	}
 	return ""
 }

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -27,10 +27,13 @@ func Authorization(auth Authorizer) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) (err error) {
 			err = auth.Authorize(c.Request())
-			if errors.Is(err, ErrUnauthorized) {
-				c.Response().WriteHeader(http.StatusUnauthorized)
+			if err != nil {
+				if errors.Is(err, ErrUnauthorized) {
+					c.Response().WriteHeader(http.StatusUnauthorized)
+				}
+				return
 			}
-			return
+			return next(c)
 		}
 	}
 }

--- a/pkg/api/middleware/authorization.go
+++ b/pkg/api/middleware/authorization.go
@@ -68,9 +68,16 @@ func NewTagAuthorizer(db storage.Storage, log echo.Logger) *TagAuthorizer {
 // If request tag is among the ones associated with the resource,
 // then action is granted. Otherwise it is denied.
 func (a *TagAuthorizer) Authorize(r *http.Request) error {
-	if !isModificationMethod(r.Method) {
-		// Only modification methods
+	if isReadMethod(r.Method) {
+		// Read HTTP methods do not
 		// require authorization
+		return nil
+	}
+
+	entityID := parseEntityID(r.URL.Path)
+	if r.Method == http.MethodPost && entityID == "" {
+		// Authorize creation operations.
+		// E.g.: POST /findings
 		return nil
 	}
 
@@ -83,12 +90,10 @@ func (a *TagAuthorizer) Authorize(r *http.Request) error {
 	// Findings and Assets as these are the entities
 	// that are related with a team
 	if isFindingOp(r.URL.Path) {
-		findingID := parseEntityID(r.URL.Path)
-		return a.authorizeFindingOp(findingID, authTag)
+		return a.authorizeFindingOp(entityID, authTag)
 	}
 	if isTargetOp(r.URL.Path) {
-		targetID := parseEntityID(r.URL.Path)
-		return a.authorizeTargetOp(targetID, authTag)
+		return a.authorizeTargetOp(entityID, authTag)
 	}
 
 	// Deny by default
@@ -151,7 +156,7 @@ func parseAuthTag(headers http.Header) string {
 }
 
 func parseEntityID(path string) string {
-	if pathParts := strings.Split(path, "/"); len(pathParts) > 1 {
+	if pathParts := strings.Split(path, "/"); len(pathParts) > 2 {
 		return pathParts[2]
 	}
 	return ""
@@ -175,10 +180,10 @@ func errToStatus(err error) int {
 	return status
 }
 
-func isModificationMethod(method string) bool {
-	return method == http.MethodPut ||
-		method == http.MethodPatch ||
-		method == http.MethodDelete
+func isReadMethod(method string) bool {
+	return method == http.MethodGet ||
+		method == http.MethodHead ||
+		method == http.MethodOptions
 }
 
 func contains(slice []string, s string) bool {

--- a/pkg/api/middleware/authorization_test.go
+++ b/pkg/api/middleware/authorization_test.go
@@ -1,0 +1,279 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/adevinta/vulnerability-db-api/pkg/model"
+	"github.com/adevinta/vulnerability-db-api/pkg/storage"
+	echo "github.com/labstack/echo"
+)
+
+var (
+	mockStorageErr = errors.New("error")
+)
+
+// MockAuthorizer is a mock implementation of
+// the Authorizer interface which returns the
+// inner err when calling its Authorize method.
+type mockAuthorizer struct {
+	err error
+}
+
+func (a *mockAuthorizer) Authorize(r *http.Request) error {
+	return a.err
+}
+
+type mockResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (m *mockResponseWriter) WriteHeader(code int) {
+	m.status = code
+}
+
+func TestAuthorization(t *testing.T) {
+	testCases := []struct {
+		name       string
+		auth       Authorizer
+		wantStatus int
+		wantErr    error
+	}{
+		{
+			name:       "Happy path",
+			auth:       &mockAuthorizer{nil},
+			wantStatus: http.StatusOK,
+			wantErr:    nil,
+		},
+		{
+			name:       "Should return 404 Not Found",
+			auth:       &mockAuthorizer{errNotFound},
+			wantStatus: http.StatusNotFound,
+			wantErr:    errNotFound,
+		},
+		{
+			name:       "Should return 401 Unauthorized",
+			auth:       &mockAuthorizer{errUnauthorized},
+			wantStatus: http.StatusUnauthorized,
+			wantErr:    errUnauthorized,
+		},
+		{
+			name:       "Should return 403 Forbidden",
+			auth:       &mockAuthorizer{errForbidden},
+			wantStatus: http.StatusForbidden,
+			wantErr:    errForbidden,
+		},
+	}
+
+	mockHandlerFunc := func(c echo.Context) (err error) {
+		c.Response().WriteHeader(http.StatusOK)
+		return nil
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRW := &mockResponseWriter{}
+			err := Authorization(tc.auth)(mockHandlerFunc)(
+				echo.New().NewContext(nil, mockRW),
+			)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected err to be %v, but got %v instead",
+					tc.wantErr, err)
+			}
+			if mockRW.status != tc.wantStatus {
+				t.Fatalf("expected response status to be %d, but got %d instead",
+					tc.wantStatus, mockRW.status)
+			}
+		})
+	}
+
+}
+
+type mockStorage struct {
+	storage.Storage
+	findings    map[string]model.FindingExpanded
+	findingsErr bool
+	targets     map[string]model.Target
+	targetsErr  bool
+}
+
+func (m *mockStorage) GetFinding(id string) (model.FindingExpanded, error) {
+	if m.findingsErr {
+		return model.FindingExpanded{}, mockStorageErr
+	}
+	if f, ok := m.findings[id]; ok {
+		return f, nil
+	}
+	return model.FindingExpanded{}, nil // Not found
+}
+
+func (m *mockStorage) GetTarget(id string) (model.Target, error) {
+	if m.targetsErr {
+		return model.Target{}, mockStorageErr
+	}
+	if t, ok := m.targets[id]; ok {
+		return t, nil
+	}
+	return model.Target{}, nil // Not found
+}
+
+type mockLogger struct {
+	echo.Logger
+}
+
+func (l *mockLogger) Errorf(format string, args ...interface{}) {
+	// Do nothing logger
+}
+
+func TestTagAuthorizer_Authorize(t *testing.T) {
+	testCases := []struct {
+		name        string
+		req         *http.Request
+		findingsErr bool
+		targetsErr  bool
+		wantErr     error
+	}{
+		{
+			name: "Authorization not required",
+			req: &http.Request{
+				Method: http.MethodGet,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Authorized for findings",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=tagf1"},
+				},
+				URL: &url.URL{Path: "/findings/f1"},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Authorized for targets",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=tagt1"},
+				},
+				URL: &url.URL{Path: "/targets/t1"},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Unauthorized, header doest not match schema",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"giberish"},
+				},
+			},
+			wantErr: errUnauthorized,
+		},
+		{
+			name: "Not Found, finding not found",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=giberish"},
+				},
+				URL: &url.URL{Path: "/findings/giberish"},
+			},
+			wantErr: errNotFound,
+		},
+		{
+			name: "Not Found, target not found",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=giberish"},
+				},
+				URL: &url.URL{Path: "/targets/giberish"},
+			},
+			wantErr: errNotFound,
+		},
+		{
+			name: "Forbidden, tag not found for finding",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=giberish"},
+				},
+				URL: &url.URL{Path: "/findings/f1"},
+			},
+			wantErr: errForbidden,
+		},
+		{
+			name: "Forbidden, tag not found for target",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=giberish"},
+				},
+				URL: &url.URL{Path: "/targets/t1"},
+			},
+			wantErr: errForbidden,
+		},
+		{
+			name: "Internal error for findings",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=tagf1"},
+				},
+				URL: &url.URL{Path: "/findings/f1"},
+			},
+			findingsErr: true,
+			wantErr:     mockStorageErr,
+		},
+		{
+			name: "Internal error for targets",
+			req: &http.Request{
+				Method: http.MethodPut,
+				Header: http.Header{
+					"Authorization": []string{"TAG tag=tagt1"},
+				},
+				URL: &url.URL{Path: "/targets/t1"},
+			},
+			targetsErr: true,
+			wantErr:    mockStorageErr,
+		},
+	}
+
+	mockStorage := &mockStorage{
+		findings: map[string]model.FindingExpanded{
+			"f1": {
+				Finding: model.Finding{ID: "f1"},
+				Target:  model.Target{Tags: []string{"tagf1"}},
+			},
+		},
+		targets: map[string]model.Target{
+			"t1": {
+				ID:   "t1",
+				Tags: []string{"tagt1"},
+			},
+		},
+	}
+
+	mockLogger := &mockLogger{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set mock flags for err behavior
+			mockStorage.findingsErr = tc.findingsErr
+			mockStorage.targetsErr = tc.targetsErr
+
+			auth := NewTagAuthorizer(mockStorage, mockLogger)
+
+			err := auth.Authorize(tc.req)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected err to be %v, but got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/pkg/api/middleware/authorization_test.go
+++ b/pkg/api/middleware/authorization_test.go
@@ -154,9 +154,16 @@ func TestTagAuthorizer_Authorize(t *testing.T) {
 		wantErr     error
 	}{
 		{
-			name: "Authorization not required",
+			name: "Authorization not required for GET",
 			req: &http.Request{
 				Method: http.MethodGet,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Authorization not required for POST",
+			req: &http.Request{
+				Method: http.MethodPost,
 			},
 			wantErr: nil,
 		},

--- a/pkg/api/middleware/authorization_test.go
+++ b/pkg/api/middleware/authorization_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	mockStorageErr = errors.New("error")
+	errMockStorage = errors.New("error")
 )
 
 // MockAuthorizer is a mock implementation of
@@ -102,7 +102,7 @@ type mockStorage struct {
 
 func (m *mockStorage) GetFinding(id string) (model.FindingExpanded, error) {
 	if m.findingsErr {
-		return model.FindingExpanded{}, mockStorageErr
+		return model.FindingExpanded{}, errMockStorage
 	}
 	if f, ok := m.findings[id]; ok {
 		return f, nil
@@ -112,7 +112,7 @@ func (m *mockStorage) GetFinding(id string) (model.FindingExpanded, error) {
 
 func (m *mockStorage) GetTarget(id string) (model.Target, error) {
 	if m.targetsErr {
-		return model.Target{}, mockStorageErr
+		return model.Target{}, errMockStorage
 	}
 	if t, ok := m.targets[id]; ok {
 		return t, nil
@@ -129,6 +129,23 @@ func (l *mockLogger) Errorf(format string, args ...interface{}) {
 }
 
 func TestTagAuthorizer_Authorize(t *testing.T) {
+	mockStorage := &mockStorage{
+		findings: map[string]model.FindingExpanded{
+			"f1": {
+				Finding: model.Finding{ID: "f1"},
+				Target:  model.Target{Tags: []string{"tagf1"}},
+			},
+		},
+		targets: map[string]model.Target{
+			"t1": {
+				ID:   "t1",
+				Tags: []string{"tagt1"},
+			},
+		},
+	}
+
+	mockLogger := &mockLogger{}
+
 	testCases := []struct {
 		name        string
 		req         *http.Request
@@ -229,7 +246,7 @@ func TestTagAuthorizer_Authorize(t *testing.T) {
 				URL: &url.URL{Path: "/findings/f1"},
 			},
 			findingsErr: true,
-			wantErr:     mockStorageErr,
+			wantErr:     errMockStorage,
 		},
 		{
 			name: "Internal error for targets",
@@ -241,26 +258,9 @@ func TestTagAuthorizer_Authorize(t *testing.T) {
 				URL: &url.URL{Path: "/targets/t1"},
 			},
 			targetsErr: true,
-			wantErr:    mockStorageErr,
+			wantErr:    errMockStorage,
 		},
 	}
-
-	mockStorage := &mockStorage{
-		findings: map[string]model.FindingExpanded{
-			"f1": {
-				Finding: model.Finding{ID: "f1"},
-				Target:  model.Target{Tags: []string{"tagf1"}},
-			},
-		},
-		targets: map[string]model.Target{
-			"t1": {
-				ID:   "t1",
-				Tags: []string{"tagt1"},
-			},
-		},
-	}
-
-	mockLogger := &mockLogger{}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/middleware/authorization_test.go
+++ b/pkg/api/middleware/authorization_test.go
@@ -157,6 +157,7 @@ func TestTagAuthorizer_Authorize(t *testing.T) {
 			name: "Authorization not required for GET",
 			req: &http.Request{
 				Method: http.MethodGet,
+				URL:    &url.URL{Path: "/findings/f1"},
 			},
 			wantErr: nil,
 		},
@@ -164,6 +165,7 @@ func TestTagAuthorizer_Authorize(t *testing.T) {
 			name: "Authorization not required for POST",
 			req: &http.Request{
 				Method: http.MethodPost,
+				URL:    &url.URL{Path: "/findings"},
 			},
 			wantErr: nil,
 		},
@@ -196,6 +198,7 @@ func TestTagAuthorizer_Authorize(t *testing.T) {
 				Header: http.Header{
 					"Authorization": []string{"giberish"},
 				},
+				URL: &url.URL{Path: "/findings/f1"},
 			},
 			wantErr: errUnauthorized,
 		},


### PR DESCRIPTION
This PR adds a new authorization middleware applicable only for modification operations on _findings_ and _target_ resources, which are the resources susceptible to be modified by end users.

Authorization middleware can be plugable with different authorization mechanisms complying with _Authorizer_ interface. Currently the only implementation inspects the authorization header and parses it following the custom TAG scheme, which indicates the tag associated with the team who has ownership of the resource. This tag is compared with the ones associated with the finding/target in order to grant or deny the request.