### PR TITLE
Add details and resources fields to FindingEvents entity

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -93,11 +93,13 @@ type FindingExpanded struct {
 
 // FindingEvent represents the event of discovering a Finding.
 type FindingEvent struct {
-	ID        string    `json:"id" db:"id"`
-	FindingID string    `json:"finding_id" db:"finding_id"`
-	SourceID  string    `json:"source_id" db:"source_id"`
-	Score     float32   `json:"score" db:"score"`
-	Time      time.Time `json:"time" db:"time"`
+	ID        string     `json:"id" db:"id"`
+	FindingID string     `json:"finding_id" db:"finding_id"`
+	SourceID  string     `json:"source_id" db:"source_id"`
+	Score     float32    `json:"score" db:"score"`
+	Details   *string    `json:"details" db:"details"`
+	Resources *Resources `json:"resources"`
+	Time      time.Time  `json:"time" db:"time"`
 }
 
 // FindingExposure represents the exposure time of a Finding.


### PR DESCRIPTION
This pull request fixes the broken end-to-end tests for this repository. 

The tests were broken due the creation of two new fields in the FindingEvents table, see here: https://github.com/adevinta/vulnerability-db/pull/7

This PR simply adds these new fields to the necessary struct.