### PR TITLE
Make paginated queries to return deterministic results

### DIFF
--- a/pkg/storage/postgresql/findings.go
+++ b/pkg/storage/postgresql/findings.go
@@ -181,9 +181,11 @@ func (db DB) ListFindings(filter storage.Filter) ([]model.FindingExpanded, stora
 	{{ if .IssueID }}
 	AND f.issue_id = :issueID
 	{{ end }}
+	ORDER BY 
 	{{ if .SortBy.Field }}
-	ORDER BY {{ .SortBy.Field}} {{ .SortBy.Order }}
+		{{ .SortBy.Field}} {{ .SortBy.Order }},
 	{{ end }}
+	f.id
 	LIMIT :limit OFFSET :offset
 	`, filter)
 	if err != nil {

--- a/pkg/storage/postgresql/issues.go
+++ b/pkg/storage/postgresql/issues.go
@@ -214,9 +214,9 @@ func (db DB) IssuesSummary(filter storage.Filter) ([]model.IssueSummary, storage
 	{{ end }}
 	group by i.id, i.summary
 	{{ if .SortBy.Field }}
-	ORDER BY {{ .SortBy.Field}} {{ .SortBy.Order }}
+	ORDER BY {{ .SortBy.Field}} {{ .SortBy.Order }}, i.id
 	{{ else }}
-	ORDER BY max_score desc, targets_count desc, summary asc
+	ORDER BY max_score desc, targets_count desc, summary asc, i.id
 	{{ end }}
 	LIMIT :limit
 	OFFSET :offset

--- a/pkg/storage/postgresql/targets.go
+++ b/pkg/storage/postgresql/targets.go
@@ -356,7 +356,7 @@ func (db DB) TargetsSummary(filter storage.Filter) ([]model.TargetSummary, stora
 	AND tt.tag = :tag
 	{{ end }}
 	group by t.id, identifier
-	ORDER BY max_score desc, findings_count desc, identifier asc
+	ORDER BY max_score desc, findings_count desc, identifier asc, t.id
 	LIMIT :limit
     OFFSET :offset
 	`, filter)


### PR DESCRIPTION
Queries from VulnDB are sorted by fields that sometimes are not unique, therefore the results returned are not deterministic. 
The impact is that paginated queries will return the same row in multiple pages, which is not what one can expect.

This PR modifies the paginated queries (see below) to consider the Table ID (either from Assets, Issues of Findings) as the `sort step`.

- ListFindings
- IssuesSummary
- TargetsSummary

Ref: https://www.postgresql.org/docs/9.6/queries-order.html