### PR TITLE
.github/workflows: add Lava workflow

### DIFF
--- a/.github/workflows/lava.yaml
+++ b/.github/workflows/lava.yaml
@@ -1,0 +1,20 @@
+# Copyright 2023 Adevinta
+
+name: Lava
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  lava:
+    name: Lava
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build . -t lava-target-image
+      - name: Run Lava Action
+        uses: adevinta/lava-action@main
+        with:
+          version: latest
+          config: lava.yaml

--- a/checktypes.json
+++ b/checktypes.json
@@ -1,0 +1,151 @@
+{
+    "checktypes": [
+        {
+            "name": "vulcan-gitleaks",
+            "description": "Detect hardcoded secrets using Gitleaks",
+            "image": "vulcansec/vulcan-gitleaks:edge",
+            "timeout": 600,
+            "options": {
+                "branch": "",
+                "depth": 1,
+                "excludedRules": []
+            },
+            "required_vars": [
+                "GITHUB_ENTERPRISE_ENDPOINT",
+                "GITHUB_ENTERPRISE_TOKEN"
+            ],
+            "assets": [
+                "GitRepository"
+            ]
+        },
+
+        {
+            "name": "vulcan-trivy",
+            "description": "Find vulnerabilities, misconfigurations and secrets using Trivy",
+            "image": "vulcansec/vulcan-trivy:edge",
+            "timeout": 600,
+            "required_vars": [
+                "REGISTRY_DOMAIN",
+                "REGISTRY_USERNAME",
+                "REGISTRY_PASSWORD",
+                "GITHUB_ENTERPRISE_ENDPOINT",
+                "GITHUB_ENTERPRISE_TOKEN"
+            ],
+            "assets": [
+                "DockerImage",
+                "GitRepository"
+            ],
+            "options": {
+                "depth": 1,
+                "branch": "",
+                "git_checks": {
+                    "vuln": true,
+                    "secret": true,
+                    "config": true
+                },
+                "image_checks": {
+                    "vuln": true,
+                    "secret": true,
+                    "config": true
+                },
+                "force_update_db": false,
+                "offline_scan": false,
+                "ignore_unfixed": false,
+                "severities": "",
+                "disable_custom_secret_config": false,
+                "scan_image_metadata": true
+            }
+        },
+
+        {
+            "name": "vulcan-semgrep",
+            "description": "Scan code for potential security issues using Semgrep",
+            "image": "vulcansec/vulcan-semgrep:edge",
+            "timeout": 600,
+            "options": {
+                "branch": "",
+                "depth": 1,
+                "exclude": [],
+                "exclude_rule": [],
+                "ruleset": [
+                    "p/r2c-security-audit"
+                ],
+                "timeout": 540
+            },
+            "required_vars": [
+                "GITHUB_ENTERPRISE_ENDPOINT",
+                "GITHUB_ENTERPRISE_TOKEN"
+            ],
+            "assets": [
+                "GitRepository"
+            ]
+        },
+
+        {
+            "name": "vulcan-retirejs",
+            "description": "Detect the use of JS-library versions with known vulnerabilities using Retire.js",
+            "image": "vulcansec/vulcan-retirejs:edge",
+            "timeout": 600,
+            "required_vars": null,
+            "assets": [
+                "Hostname",
+                "WebAddress"
+            ]
+        },
+
+        {
+            "name": "vulcan-zap",
+            "description": "Run an OWASP ZAP vulnerability scan",
+            "image": "vulcansec/vulcan-zap:edge",
+            "timeout": 600,
+            "options": {
+                "depth": 2,
+                "active": true,
+                "username": "",
+                "password": "",
+                "min_score": 0,
+                "disabled_scanners": [
+                    "10062",
+                    "10003",
+                    "10108"
+                ],
+                "ignored_fingerprint_scanners": [
+                    "40018"
+                ],
+                "max_spider_duration": 0,
+                "max_scan_duration": 9,
+                "max_rule_duration": 0,
+                "openapi_url": "",
+                "openapi_host": ""
+            },
+            "required_vars": null,
+            "assets": [
+                "WebAddress"
+            ]
+        },
+
+        {
+            "name": "vulcan-nuclei",
+            "description": "Run a Nuclei vulnerability scan",
+            "image": "vulcansec/vulcan-nuclei:edge",
+            "timeout": 600,
+            "options": {
+                "update_templates": false,
+                "severities": [],
+                "template_inclusion_list": [],
+                "template_exclusion_list": [],
+                "tag_inclusion_list": [],
+                "tag_exclusion_list": [
+                    "intrusive",
+                    "dos",
+                    "fuzz"
+                ]
+            },
+            "required_vars": null,
+            "assets": [
+                "WebAddress",
+                "Hostname"
+            ]
+        }
+    ]
+}

--- a/lava.yaml
+++ b/lava.yaml
@@ -12,3 +12,5 @@ agent:
   parallel: 4
 report:
   severity: high
+  exclusions:
+    - summary: 'Dockerfile Security Check - Image user should not be ''root'''

--- a/lava.yaml
+++ b/lava.yaml
@@ -1,0 +1,14 @@
+# Copyright 2023 Adevinta
+
+lava: v0.0.0
+checktypesURLs:
+  - checktypes.json
+targets:
+  - identifier: .
+    assetType: GitRepository
+  - identifier: lava-target-image
+    assetType: DockerImage
+agent:
+  parallel: 4
+report:
+  severity: high


### PR DESCRIPTION
This PR adds a new workflow that runs Lava as part of the checks
executed on `push` and `pull_request` events. For now this check will
not be set as required.

Also, I excluded the following issue:

```
Dockerfile Security Check - Image user should not be 'root'
```

It seems that `run.sh` expects the image user to be root and changing
it, I think, would be out of the scope of this PR. For instance,

https://github.com/adevinta/vulnerability-db-api/blob/35b686ac6416fc7c0a3b9e6c779eabc74e27a533/run.sh#L16-L20